### PR TITLE
Fixing bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /misc/*
 testbench.py
 /*.egg-info/*
+/data

--- a/mine/models.py
+++ b/mine/models.py
@@ -9,6 +9,17 @@ from mine.utils import logSumExp, RegressionDataset
 
 class MINE(nn.Module):
     def __init__(self, inputSpaceDim, archSpecs, divergenceMeasure='KL', learningRate=1e-4):
+        """Initializes the MINE model.
+
+        Args:
+          inputSpaceDim: The dimension of the input space. 
+          archSpecs: Architecture specifications containing layer sizes and activation functions.
+          divergenceMeasure: The divergence measure to use, either 'KL' or 'JS'.
+          learningRate: The learning rate for the Adam optimizer.
+
+        The constructor initializes the neural network layers, activation functions, 
+        divergence measure, and Adam optimizer according to the provided specifications.
+        """
         super().__init__()
         layerSizes = archSpecs['layerSizes'] + [1]
         self.activationFunctions = archSpecs['activationFunctions']
@@ -35,7 +46,15 @@ class MINE(nn.Module):
 
     def calcMI(self, xSamplesJoint, ySamplesJoint, xSamplesMarginal, ySamplesMarginal, numEpochs=500,
                batchSize=None, smoothCoeff=0.01):
+        '''
+            xSamplesJoint: Samples from the joint distribution p(x,y)
+            ySamplesJoint: Samples from the joint distribution p(x,y)
+            xSamplesMarginal: Samples from the marginal distribution p(x)
+            ySamplesMarginal: Samples from the marginal distribution p(y)
+            The mutual information is then calculated as:MI(X,Y) = Ep(x,y)[f(x,y)] - Ep(x)p(y)[f(x,y)]Where f(x,y) is the output of the trained network.
+        '''
         numSamplesJoint = xSamplesJoint.shape[0]
+        # assert return true or false
         assert ySamplesJoint.shape[0] == numSamplesJoint
         assert ySamplesMarginal.shape[0] == xSamplesMarginal.shape[0]
 

--- a/mine_audio.py
+++ b/mine_audio.py
@@ -1,0 +1,37 @@
+import soundfile
+import numpy as np
+import random
+
+
+def loadWAV(filename, max_frames):
+    
+    max_audio = max_frames * 160 + 240
+    # Read wav file and convert to torch tensor
+    audio, sample_rate = soundfile.read(filename)
+
+    audiosize = audio.shape[0]
+
+    if audiosize <= max_audio:
+        shortage = max_audio - audiosize + 1
+        audio = np.pad(audio, (0, shortage), 'wrap')
+        audiosize = audio.shape[0]
+
+    startframe = np.array(
+            [np.int64(random.random()*(audiosize-max_audio))])
+
+    feats = []
+
+    for asf in startframe:
+        feats.append(audio[int(asf):int(asf)+max_audio])
+
+    feat = np.stack(feats, axis=0).astype(np.float64)
+
+    return feat
+
+
+if __name__ == '__main__':
+    speaker_1_s_1 = loadWAV('./data/1_00001.wav',
+                            0)
+    speaker_1_s_2 = loadWAV('./data/1_00002.wav',
+                            0)
+    print(speaker_1_s_1)


### PR DESCRIPTION
Instead of using np.asscalar and detach().numpy(), the code now uses mi.item() directly to append the value to miHistory. This is a more concise and efficient way of obtaining the scalar value of a tensor.

The return statement for the MI value was modified to directly return mi.item() instead of using np.asscalar and data.numpy().